### PR TITLE
If WOODEN-DOOR is going to be a local global object...

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -2169,7 +2169,14 @@ suddenly vanish." CR CR>)>
 	       (<VERB? MUNG>
 		<TELL "You can't seem to damage the door." CR>)
 	       (<VERB? LOOK-BEHIND>
-		<TELL "It won't open." CR>)>>
+		<TELL "It won't open." CR>)
+	       (<VERB? READ>
+		<COND (<EQUAL? ,HERE ,LIVING-ROOM>
+		       <TELL
+"The engravings translate to \"This space intentionally left blank.\"">)
+		      (<TELL
+"There is no writing on this side.">)>
+		<CRLF>)>>
 
 \
 

--- a/dungeon.zil
+++ b/dungeon.zil
@@ -907,7 +907,7 @@ Zorkers were obscure." )>
 	(SYNONYM DOOR LETTERING WRITING)
 	(ADJECTIVE WOODEN GOTHIC STRANGE WEST)
 	(DESC "wooden door")
-	(FLAGS READBIT DOORBIT NDESCBIT TRANSBIT)
+	(FLAGS DOORBIT NDESCBIT TRANSBIT)
 	(ACTION FRONT-DOOR-FCN)
 	(TEXT
 "The engravings translate to \"This space intentionally left blank.\"")>
@@ -1747,7 +1747,8 @@ cyclops sized).")
       (WEST TO CYCLOPS-ROOM)
       (IN TO CYCLOPS-ROOM)
       (EAST TO LIVING-ROOM)
-      (FLAGS RLANDBIT)>
+      (FLAGS RLANDBIT)
+      (GLOBAL WOODEN-DOOR)>
 
 <ROOM TREASURE-ROOM
       (IN ROOMS)


### PR DESCRIPTION
If ```WOODEN-DOOR``` is going to be a local global object, it should be visible from ```STRANGE-PASSAGE``` as well. But in that case, we also need to make sure that the gothic lettering is only visible from ```LIVING-ROOM```.

I'm a bit reluctant to make this kind of change to the game, so this is mostly intended as a reminder. ```WOODEN-DOOR``` used to be visible only from ```LIVING-ROOM```, but that was changed as a part of https://github.com/the-infocom-files/zork1/issues/4 (even though that bug report was only about ```TRAP-DOOR```).

Also, _if_ this change is accepted, please note that "There is no writing on this side." is only a temporary message. Feel free to change it to something better.